### PR TITLE
Create CNAME file ready for www.machinekit.io DNS redirection

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.machinekit.io


### PR DESCRIPTION
Needed for GitHub servers to do the right thing once the `www.machinekit.io` `CNAME` entry points at GitHub servers.

https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages
