### PR TITLE
Docs addition for independent hosted 3.4.55-rtai-2 packages

### DIFF
--- a/docs/packages-debian.md
+++ b/docs/packages-debian.md
@@ -54,9 +54,18 @@ This archive is currently unsigned. Apt will complain; simply answer
 - **RTAI kernel**
 
   The machinekit repo builds and runs fine on RTAI. However, we currently
-  do not have a sufficiently recent RTAI kernel available as a package. You need
-  to build from source to match your RTAI version. Builds are known
-  to work with the 2.6.32-122-rtai and 3.4.55 kernels from the LinuxCNC project. 
+  do not have a sufficiently recent RTAI kernel available as a package here.
+  
+  In the interim there are some independently hosted 3.4.55-rtai-2 kernel packages 
+  which run on Wheezy and against which MachineKit builds on x86, here
+  
+  http://deb.mgware.co.uk
+  
+  Follow the instructions at that address
+  
+  (The packages are essentially the same ones as on Seb Kuzminsky's site,
+  http://highlab.com/~seb/linuxcnc/rtai-for-3.4-prerelease/
+  with a hack to prevent some symlinks being clobbered which prevented MK building against them)
 
 
 ### Other things to do


### PR DESCRIPTION
Interim additions of my repo address until rtai kernels on the buildbot
