### PR TITLE
Initial commit of docs/community page; quick links

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,6 +1,7 @@
 - title: Getting Started
   docs:
     - packages-debian
+    - community
 
 - title: Development
   docs:

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,56 @@
+---
+layout: docs
+title: Community
+prev_section: packages-debian
+permalink: /docs/community/
+---
+
+## Community channels
+
+The Machinekit community gathers around the [Google group][1] and the
+[GitHub issue tracker][2].
+
+
+## Machinekit Google group
+
+Users and developers discuss Machinekit in the [Machinekit Google
+group][1].  The group can be accessed via the web or subscribed to as
+an email list:
+
+- View the group in a web-based forum-like format at
+  [http://groups.google.com/group/machinekit][1]
+
+- Subscribe in list format by sending an email to
+  [machinekit+subscribe@googlegroups.com][4].  (Be sure to reply to
+  Google's join request confirmation email.)
+
+Both means are equivalent, and give access to the same postings.
+
+
+## Machinekit GitHub issue tracker
+
+Report problems with Machinekit on the [GitHub issue tracker][2].
+When submitting an issue, please:
+
+- Choose a meaningful title
+
+- Provide a clear description of the problem
+
+- Paste error messages or other output useful for debugging
+
+When pasting output, which may contain special characters interpreted
+as text formatting by [GitHub-flavored markdown][3], quote it using
+three backtick characters as in the following example:
+
+    ```
+    MODPOST 1 modules
+    WARNING: "rtapi_print_msg" [/tmp/tmpbbJkRv/test_define.ko] undefined!
+    ```
+
+Before submitting, check the `Preview` tab above the edit window to
+make sure the output formatting is sane.
+
+[1]:  http://groups.google.com/group/machinekit
+[2]:  https://github.com/machinekit/machinekit/issues
+[3]:  https://help.github.com/articles/github-flavored-markdown
+[4]:  mailto:machinekit+subscribe@googlegroups.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,24 @@ This documentation is to help users and developers get started.  It
 will cover topics such as installing packages, setting up a
 development environment, and community participation.
 
+Please browse the topics in the navigation bar on the right.  Quick
+links are provided for convenience below.
+
+
+## Community links
+
+- Machinekit Google group:  <http://groups.google.com/group/machinekit>
+
+- Machinekit GitHub issue tracker:
+  <https://github.com/machinekit/machinekit/issues> 
+
+- Machinekit Blog:  <http://blog.machinekit.io/>
+
+
 ## Development quick links
 
 - GitHub site:  <https://github.com/machinekit/machinekit/>
+
 - Buildbot grid:  <http://buildbot.dovetail-automata.com/grid>
+
 - Buildbot results:  <http://buildbot.dovetail-automata.com/results/>

--- a/docs/packages-debian.md
+++ b/docs/packages-debian.md
@@ -1,6 +1,7 @@
 ---
 layout: docs
 title: Debian packages
+next_section: community
 permalink: /docs/packages-debian/
 ---
 


### PR DESCRIPTION
Some additions esp. to help orient new users.
- Community page with information about the MK list and issue tracker
- `Community links` section on main doc page
  - Includes links omitted before
