### PR TITLE
docs : add info on installing libzmq4-dev package and cython 0.19

### DIFF
--- a/docs/packages-debian.md
+++ b/docs/packages-debian.md
@@ -41,10 +41,19 @@ List of RTOS choices:
 For those wanting a development environment, run:
 
     sudo apt-get install libczmq-dev python-zmq libjansson-dev \
-        libwebsockets-dev libxenomai-dev
+        libwebsockets-dev libxenomai-dev libzmq4-dev
 
 This archive is currently unsigned. Apt will complain; simply answer
 'y' to its warnings.
+
+Further more, add wheezy-backports in the package archive for cython 0.19
+
+    sudo sh -c \
+        "echo 'deb http://ftp.us.debian.org/debian wheezy-backports main' > \
+         /etc/apt/sources.list.d/wheezy-backports.list"
+    sudp apt-get update
+    sudo apt-get install -t wheezy-backports cython
+
 
 - **Beaglebone kernel note**
 
@@ -61,9 +70,9 @@ This archive is currently unsigned. Apt will complain; simply answer
   In the interim there are some independently hosted 3.4.55-rtai-2
   kernel packages which run on Wheezy and against which MachineKit
   builds on x86 [http://deb.mgware.co.uk](http://deb.mgware.co.uk)
-  
+
   Follow the instructions at that address.
-  
+
   - *NB.* The packages are essentially the same ones as on Seb
     Kuzminsky's site,
     [http://highlab.com/~seb/linuxcnc/rtai-for-3.4-prerelease/]
@@ -76,4 +85,3 @@ This archive is currently unsigned. Apt will complain; simply answer
 
 - Browse the Debian archive directly at
   [http://deb.dovetail-automata.com/pool/](http://deb.dovetail-automata.com/pool/)
-


### PR DESCRIPTION
I needed to add libzmq4-dev to the packages, as well as add cython from wheezy-backports. This I added to the docs. If this needs additional instruction, please let me know what to type
Bas
