### PR TITLE
changed documentation start to welcome

### DIFF
--- a/_data/docs.yml
+++ b/_data/docs.yml
@@ -1,5 +1,6 @@
 - title: Getting Started
   docs:
+    - home
     - packages-debian
     - community
 

--- a/_includes/primary-nav-items.html
+++ b/_includes/primary-nav-items.html
@@ -6,7 +6,7 @@
     <a href="/about/">About</a>
   </li>
   <li class="{% if page.url contains '/docs/' %}current{% endif %}">
-    <a href="/docs/">
+    <a href="/docs/home/">
       <span class="hide-on-mobiles">Documentation</span>
       <span class="show-on-mobiles">Docs</span>
     </a>

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,8 +1,8 @@
 ---
 layout: docs
-title: Documentation Start
+title: Welcome
 next_section: packages-debian
-permalink: /docs/
+permalink: /docs/home/
 ---
 
 This documentation is to help users and developers get started.  It


### PR DESCRIPTION
I changed the name of the documentation index page to welcome and added it to the navigation. This is similar to how it is done on the Jekyll website.
