### PR TITLE
Use first non-merge commit

### DIFF
--- a/.github/workflows/build-on-ping.yaml
+++ b/.github/workflows/build-on-ping.yaml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ACTING_SHA: ${{ github.event.client_payload.sha }}
-      POSITION_FROM_TOP: 2
       OUTPUT_NAME: 'machinekit-site-${{ github.event.client_payload.sha }}'
       ACTING_REPOSITORY: ${{ github.event.client_payload.originating_repository }}
     steps:
@@ -63,8 +62,8 @@ jobs:
           echo "###########################################################"
           echo "# Commit which will be used for mining of the credentials #"
           echo "###########################################################"
-          git log -n 1 ${{ env.ACTING_SHA }}~$((${{ env.POSITION_FROM_TOP }}-1))
-          jq -n --arg authoremail "$(git log --format='%ae' -n 1 ${{ env.ACTING_SHA }}~$((${{ env.POSITION_FROM_TOP }}-1)))" --arg authorname "$(git log --format='%an' -n 1 ${{ env.ACTING_SHA }}~$((${{ env.POSITION_FROM_TOP }}-1)))" --arg commitmsg "$(git log --format='%B' -n 1 ${{ env.ACTING_SHA }}~$((${{ env.POSITION_FROM_TOP }}-1)))" --arg sha "${{ env.ACTING_SHA }}" '{"author":"\($authorname)","email":"\($authoremail)","message":"\($commitmsg)","sha":"\($sha)"}' > ${{ env.FILENAME }}
+          git log -n 1 --no-merges HEAD
+          jq -n --arg authoremail "$(git log --format='%ae' -n 1 --no-merges HEAD)" --arg authorname "$(git log --format='%an' -n 1 --no-merges HEAD)" --arg commitmsg "$(git log --format='%B' -n 1 --no-merges HEAD)" --arg sha "${{ env.ACTING_SHA }}" '{"author":"\($authorname)","email":"\($authoremail)","message":"\($commitmsg)","sha":"\($sha)"}' > ${{ env.FILENAME }}
           echo "###########################################################"
           echo "# JSON file with metadata information of pertinent commit #"
           echo "###########################################################"          


### PR DESCRIPTION
In GitHUB Actions workflow, use first non-merge commit for metadata generation. This data then will be used for creation of new commit in which the change will be merged.

Instead of non-working, convoluted and nonsense current solution.